### PR TITLE
Updated workflow badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MultiMonitorRdp
-[![Build](https://github.com/hellcat707hp/MultiMonitorRdp/actions/workflows/build.yml/badge.svg)](https://github.com/hellcat707hp/MultiMonitorRdp/actions/workflows/build.yml)
+[![Build](https://github.com/hellcat707hp/MultiMonitorRdp/workflows/Build/badge.svg)](https://github.com/hellcat707hp/MultiMonitorRdp/actions/workflows/build.yml)
 
 MultiMonitorRdp is a simple console program designed to make using Windows Remote Desktop client easier with multi-display setups. This program only exists because Windows tends to change which display numbers are which between restarts, sleeps, and even displays waking up.
 ___


### PR DESCRIPTION
The workflow badge provided by Github is having.... issues. Apparently [others have had this too](https://stackoverflow.com/questions/71863833/github-actions-badge-shows-no-status) and it's fixed by referencing a different badge svg file.