### PR TITLE
fix: corrected instances where DeviceName uses a higher number than monitor number

### DIFF
--- a/MultiMonitorRdp/MultiMonitorRdp.csproj
+++ b/MultiMonitorRdp/MultiMonitorRdp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,7 @@
 	  <UseWindowsForms>true</UseWindowsForms>
 	  <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <VersionPrefix>1.0.1</VersionPrefix>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What is the change?
Updating the logic for determining monitor "number" to not rely directly on the DeviceName's numeric ID, and instead use that as a sorting mechanism to start at 1. The DeviceNames appear to be in the same order as the monitor "number", but they don;t always start at 1, which we need to start at 1.

## Review areas to focus on
Nothing in particular

## Related PRs
None